### PR TITLE
feat: navigate to ad referral link

### DIFF
--- a/packages/components/src/ads.json
+++ b/packages/components/src/ads.json
@@ -23,6 +23,7 @@
     "company": "CodeFund",
     "pixel": [
       "https://codefund.io/p/b84b2925-65ba-4483-bc55-97b459c06136/pixel.png"
-    ]
+    ],
+    "referralLink": "https://codefund.io/invite/daily"
   }
 ]

--- a/packages/components/src/components/DaCardAd.vue
+++ b/packages/components/src/components/DaCardAd.vue
@@ -6,7 +6,9 @@
     <template slot="content">
       <img v-for="(item, index) in pixel" :key="index" :src="item" class="card__pixel"/>
     </template>
-    <span slot="footer" class="card__footer__promoted micro2">/* {{ promoted }} */</span>
+    <a slot="footer" class="card__footer__promoted micro2" target="_blank"
+       :href="ad.referralLink" v-if="ad && ad.referralLink">/* {{ promoted }} */</a>
+    <span slot="footer" class="card__footer__promoted micro2" v-else>/* {{ promoted }} */</span>
   </DaCard>
 </template>
 
@@ -64,6 +66,7 @@ export default {
 .card__footer__promoted {
   color: var(--theme-secondary);
   text-transform: uppercase;
+  text-decoration: none;
 }
 
 .card__pixel {

--- a/packages/components/src/components/DaInsaneAd.vue
+++ b/packages/components/src/components/DaInsaneAd.vue
@@ -5,7 +5,9 @@
         <da-line-clamp :text="ad.description" :lines="3"/>
       </h5>
     </a>
-    <span class="insane__promoted micro2">/* {{ promoted }} */</span>
+    <a class="insane__promoted micro2" target="_blank"
+       :href="ad.referralLink" v-if="ad && ad.referralLink">/* {{ promoted }} */</a>
+    <span class="insane__promoted micro2" v-else>/* {{ promoted }} */</span>
     <img v-for="(item, index) in pixel" :key="index" :src="item" class="insane__pixel"/>
   </div>
 </template>
@@ -51,6 +53,7 @@ export default {
 .insane__promoted {
   color: var(--theme-secondary);
   text-transform: uppercase;
+  text-decoration: none;
 }
 
 .insane__pixel {

--- a/packages/services/src/monetization.ts
+++ b/packages/services/src/monetization.ts
@@ -11,6 +11,7 @@ export interface Ad {
     pixel?: string[];
     backgroundColor?: string;
     source: string;
+    referralLink?: string;
 }
 
 export interface MonetizationService {


### PR DESCRIPTION
When dailynowco/daily-monetization#1 is closed, a referral link will be provided as part of the response.
The ad components should turn the promoted text to a link, in case a referral link is provided.

Closes #3