### PR TITLE
fix: "add to feed" button should follow style guidelines

### DIFF
--- a/packages/components/src/styles/buttons.pcss
+++ b/packages/components/src/styles/buttons.pcss
@@ -122,6 +122,12 @@ button:focus, button:active {
         --button-focus-border: var(--color-water-20);
     }
 
+    &.btn-water {
+        --button-color: var(--color-salt-10);
+        --button-background: var(--color-water-50);
+        --button-focus-border: var(--color-water-20);
+    }
+
     &.btn-invert {
         --button-color: var(--theme-primary-invert);
         --button-background: var(--theme-primary);

--- a/packages/components/stories/button.stories.js
+++ b/packages/components/stories/button.stories.js
@@ -3,6 +3,7 @@ import { withKnobs, select } from '@storybook/addon-knobs';
 
 const buttons = {
   gradient: 'btn-water-cheese',
+  water: 'btn-water',
   hollow: 'btn-hollow',
   invert: 'btn-invert',
   nav: 'btn-nav',

--- a/packages/extension/src/routes/Home.vue
+++ b/packages/extension/src/routes/Home.vue
@@ -15,7 +15,7 @@
                v-if="filter.type === 'publication'" class="content__header__pub-image"/>
           <h4>// {{ filter.info.name }}</h4>
           <transition name="fade">
-            <button class="btn content__header__add-filter" v-if="!hasFilter"
+            <button class="btn btn-water content__header__add-filter" v-if="!hasFilter"
                     @click="onAddFilter">
               <svgicon icon="plus"/>
               <span>Add To Feed</span>
@@ -414,8 +414,6 @@ export default {
 
   & .content__header__add-filter {
     margin-left: auto;
-    background: var(--color-water-50);
-    color: var(--color-salt-10);
   }
 }
 


### PR DESCRIPTION
When visiting a single source / tag which is not part of the user's feed an "add to feed" button is revealed.
As of this commit, this button didn't follow the style guidelines.

Closes #2