### PR TITLE
fix(components): switches had jagged transition

### DIFF
--- a/packages/components/__tests__/DaSwitch.js
+++ b/packages/components/__tests__/DaSwitch.js
@@ -5,6 +5,7 @@ it('should emit toggle event on click', (done) => {
   const wrapper = shallowMount(DaSwitch, { propsData: { icon: 'bookmark' } });
   wrapper.trigger('click');
   wrapper.find('.switch__handle').trigger('transitionend');
+  wrapper.find('.switch__handle').trigger('transitionend');
   setTimeout(() => {
     expect(wrapper.emitted().toggle[0]).toEqual([true]);
     done();

--- a/packages/components/src/components/DaModeSwitch.vue
+++ b/packages/components/src/components/DaModeSwitch.vue
@@ -32,8 +32,9 @@ export default {
 
   methods: {
     toggle(event) {
+      // Mechanism to prevent jagged animation
       this.$refs.handle.addEventListener('transitionend', () => {
-        requestAnimationFrame(() => {
+        setTimeout(() => {
           this.$emit('toggle', event.target.checked);
         });
       }, { once: true });

--- a/packages/components/src/components/DaSwitch.vue
+++ b/packages/components/src/components/DaSwitch.vue
@@ -36,10 +36,13 @@ export default {
 
   methods: {
     toggle(event) {
+      // Need to wait for the long transition to prevent jagged animation
       this.$refs.handle.addEventListener('transitionend', () => {
-        requestAnimationFrame(() => {
-          this.$emit('toggle', event.target.checked);
-        });
+        this.$refs.handle.addEventListener('transitionend', () => {
+          setTimeout(() => {
+            this.$emit('toggle', event.target.checked);
+          });
+        }, { once: true });
       }, { once: true });
     },
   },

--- a/packages/extension/__tests__/DaHeader.js
+++ b/packages/extension/__tests__/DaHeader.js
@@ -103,6 +103,7 @@ it('should commit "setShowBookmarks" when switch is toggled', (done) => {
   const wrapper = mount(DaHeader, { store, localVue });
   wrapper.find('.header__switch').trigger('click');
   wrapper.find('.header__switch').find('.switch__handle').trigger('transitionend');
+  wrapper.find('.header__switch').find('.switch__handle').trigger('transitionend');
   setTimeout(() => {
     expect(feed.actions.setShowBookmarks).toBeCalledWith(expect.anything(), true, undefined);
     done();


### PR DESCRIPTION
Both `DaModeSwitch` and `DaSwitch` had jagged transition because of an event that was emitted before the transitions finish.