### PR TITLE
fix(extension): switching to pubs list after searching tags

### DIFF
--- a/packages/extension/src/components/DaSidebar.vue
+++ b/packages/extension/src/components/DaSidebar.vue
@@ -227,6 +227,7 @@ export default {
     toggleFilter(checked) {
       ga('send', 'event', 'Sidebar', 'Filter', checked ? 'Tags' : 'Publications');
       this.filterChecked = checked;
+      this.query = '';
     },
     setEnablePublication(pub, enabled) {
       ga('send', 'event', 'Publications', 'Toggle', enabled ? 'Check' : 'Uncheck');


### PR DESCRIPTION
When searching for tags, changing to the publications list and then going back to tags the list kept the results of the last search although query is empty.