### PR TITLE
feat(extension): show placeholder while loading ads

### DIFF
--- a/packages/components/src/components/DaCardPlaceholder.vue
+++ b/packages/components/src/components/DaCardPlaceholder.vue
@@ -16,8 +16,6 @@
 </template>
 
 <script>
-import '../styles/placeholder.pcss';
-
 export default {
     name: 'DaCardPlaceholder',
 };
@@ -44,7 +42,7 @@ export default {
   &:before {
     content: '';
     display: block;
-    padding-top: 100.71%;
+    padding-top: 89.36%;
   }
 }
 
@@ -56,7 +54,7 @@ export default {
 
 .card-ph__image {
   top: 0;
-  height: 62%;
+  height: 57.14%;
   background: linear-gradient(180deg, var(--theme-background-secondary) 0%, var(--theme-background-primary) 100%);
 }
 

--- a/packages/components/src/styles/global.pcss
+++ b/packages/components/src/styles/global.pcss
@@ -3,6 +3,7 @@
 @import "themes.pcss";
 @import "buttons.pcss";
 @import "insane.pcss";
+@import "placeholder.pcss";
 
 html {
     --color-highlight: var(--color-water-50);

--- a/packages/extension/src/routes/Home.vue
+++ b/packages/extension/src/routes/Home.vue
@@ -58,6 +58,7 @@
       </div>
       <div class="content__insane" v-if="insaneMode">
         <template v-if="showAd">
+          <da-insane-placeholder v-if="!ads.length"/>
           <da-insane-ad v-for="(item, index) in ads" :key="index" :ad="item"
                         @click="onAdClick" @impression="onAdImpression"/>
         </template>
@@ -68,6 +69,7 @@
       </div>
       <masonry class="content__cards" :cols="cols" :gutter="32" v-else>
         <template v-if="showAd">
+          <da-card-placeholder v-if="!ads.length"/>
           <da-card-ad v-for="(item, index) in ads" :key="index" :ad="item"/>
         </template>
         <da-card-post v-for="item in posts" ref="posts" :key="item.id" :post="item"
@@ -135,8 +137,10 @@ export default {
     DaHeader,
     DaCardPost: () => import(/* webpackChunkName: "cards" */ '@daily/components/src/components/DaCardPost.vue'),
     DaCardAd: () => import(/* webpackChunkName: "cards" */ '@daily/components/src/components/DaCardAd.vue'),
+    DaCardPlaceholder: () => import(/* webpackChunkName: "cards" */ '@daily/components/src/components/DaCardPlaceholder.vue'),
     DaInsanePost: () => import(/* webpackChunkName: "insane" */ '@daily/components/src/components/DaInsanePost.vue'),
     DaInsaneAd: () => import(/* webpackChunkName: "insane" */ '@daily/components/src/components/DaInsaneAd.vue'),
+    DaInsanePlaceholder: () => import(/* webpackChunkName: "insane" */ '@daily/components/src/components/DaInsanePlaceholder.vue'),
     DaSvg,
     DaTerminal: () => import('@daily/components/src/components/DaTerminal.vue'),
     DaContext: () => import('@daily/components/src/components/DaContext.vue'),
@@ -469,7 +473,7 @@ export default {
 .content__cards {
   margin: -32px 0;
 
-  & .card {
+  & .card, & .card-ph {
     margin: 32px 0;
   }
 }


### PR DESCRIPTION
The first post in the feed is mostly a promoted content which takes more time to load than the rest of the feed. This delay causes the cards to flicker and it's pretty annoying.
This PR shows a placeholder while the ad is loading.

Closes #20