### PR TITLE
fix(components): truncate tags in insane mode

### DIFF
--- a/packages/components/__tests__/DaCardPost.js
+++ b/packages/components/__tests__/DaCardPost.js
@@ -1,6 +1,15 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount, createLocalVue } from '@vue/test-utils';
+import svgicon from 'vue-svgicon';
+import DaLineClamp from '../src/components/DaLineClamp.vue';
+import DaCard from '../src/components/DaCard.vue';
 import DaCardPost from '../src/components/DaCardPost.vue';
 import posts from '../src/posts';
+
+const localVue = createLocalVue();
+
+localVue.use(svgicon);
+localVue.component('da-line-clamp', DaLineClamp);
+localVue.component('da-card', DaCard);
 
 it('should emit bookmark event on click', () => {
   const post = posts[0];
@@ -25,7 +34,8 @@ it('should set bookmark button title', () => {
 it('should set bookmark button title when bookmarked', () => {
   const post = posts[1];
   const wrapper = shallowMount(DaCardPost, { propsData: { post } });
-  expect(wrapper.find('.card__footer__bookmark').element.title).toEqual('Remove bookmark');
+  expect(wrapper.find('.card__footer__bookmark').element.title)
+    .toEqual('Remove bookmark');
 });
 
 it('should set bookmarked class when bookmarked', () => {
@@ -34,10 +44,11 @@ it('should set bookmarked class when bookmarked', () => {
   expect(wrapper.element.classList.contains('bookmarked')).toEqual(true);
 });
 
-it('should set tags title', () => {
+it('should set tags', () => {
   const post = posts[1];
-  const wrapper = shallowMount(DaCardPost, { propsData: { post } });
-  expect(wrapper.find('.card__tags').element.title).toEqual('#javascript,#webdev,#html,#html5');
+  const wrapper = mount(DaCardPost, { localVue, propsData: { post } });
+  expect(wrapper.find('.card__tags span').element.innerHTML)
+    .toEqual('#javascript,#webdev,#html,#html5');
 });
 
 it('should show notification', () => {

--- a/packages/components/__tests__/DaInsanePost.js
+++ b/packages/components/__tests__/DaInsanePost.js
@@ -1,6 +1,13 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount, createLocalVue } from '@vue/test-utils';
+import svgicon from 'vue-svgicon';
+import DaLineClamp from '../src/components/DaLineClamp.vue';
 import DaInsanePost from '../src/components/DaInsanePost.vue';
 import posts from '../src/posts';
+
+const localVue = createLocalVue();
+
+localVue.use(svgicon);
+localVue.component('da-line-clamp', DaLineClamp);
 
 it('should emit click event', () => {
   const post = posts[0];
@@ -26,23 +33,27 @@ it('should emit menu event on click', () => {
 it('should set bookmark button title', () => {
   const post = posts[0];
   const wrapper = shallowMount(DaInsanePost, { propsData: { post } });
-  expect(wrapper.find('.insane__reveal__bookmark').element.title).toEqual('Bookmark');
+  expect(wrapper.find('.insane__reveal__bookmark').element.title)
+    .toEqual('Bookmark');
 });
 
 it('should set bookmark button title when bookmarked', () => {
   const post = posts[1];
   const wrapper = shallowMount(DaInsanePost, { propsData: { post } });
-  expect(wrapper.find('.insane__reveal__bookmark').element.title).toEqual('Remove bookmark');
+  expect(wrapper.find('.insane__reveal__bookmark').element.title)
+    .toEqual('Remove bookmark');
 });
 
 it('should set bookmarked class when bookmarked', () => {
   const post = posts[1];
   const wrapper = shallowMount(DaInsanePost, { propsData: { post } });
-  expect(wrapper.find('.insane--post').element.classList.contains('bookmarked')).toEqual(true);
+  expect(wrapper.find('.insane--post').element.classList.contains('bookmarked'))
+    .toEqual(true);
 });
 
 it('should set tags', () => {
   const post = posts[1];
-  const wrapper = shallowMount(DaInsanePost, { propsData: { post } });
-  expect(wrapper.find('.insane__tags').element.innerHTML).toEqual('#javascript,#webdev,#html,#html5');
+  const wrapper = mount(DaInsanePost, { localVue, propsData: { post } });
+  expect(wrapper.find('.insane__tags span').element.innerHTML)
+    .toEqual('#javascript,#webdev,#html,#html5');
 });

--- a/packages/components/__tests__/truncate.js
+++ b/packages/components/__tests__/truncate.js
@@ -1,0 +1,21 @@
+import {truncateTags} from '../src/truncate';
+
+it('should return empty string on empty tags', () => {
+  const actual = truncateTags([], 'hello', 10);
+  expect(actual).toEqual('');
+});
+
+it('should return empty string on no tags', () => {
+  const actual = truncateTags(null, '', 10);
+  expect(actual).toEqual('');
+});
+
+it('should return all tags when max length is big enough', () => {
+  const actual = truncateTags(['javascript', 'webdev', 'html', 'html5'], '', 100);
+  expect(actual).toEqual('#javascript,#webdev,#html,#html5');
+});
+
+it('should return truncate tags when max length is not enough', () => {
+  const actual = truncateTags(['javascript', 'webdev', 'html', 'html5'], '', 20);
+  expect(actual).toEqual('#javascript,#webdev,+2');
+});

--- a/packages/components/src/components/DaCardPlaceholder.vue
+++ b/packages/components/src/components/DaCardPlaceholder.vue
@@ -17,7 +17,7 @@
 
 <script>
 export default {
-    name: 'DaCardPlaceholder',
+  name: 'DaCardPlaceholder',
 };
 </script>
 
@@ -55,7 +55,8 @@ export default {
 .card-ph__image {
   top: 0;
   height: 57.14%;
-  background: linear-gradient(180deg, var(--theme-background-secondary) 0%, var(--theme-background-primary) 100%);
+  background: linear-gradient(180deg, var(--theme-background-secondary) 0%,
+  var(--theme-background-primary) 100%);
 }
 
 .card-ph__content {

--- a/packages/components/src/components/DaCardPost.vue
+++ b/packages/components/src/components/DaCardPost.vue
@@ -1,5 +1,5 @@
 <template>
-  <DaCard class="card--post" :class="cls" :title="post.title" :url="post.url" :image="post.image"
+  <da-card class="card--post" :class="cls" :title="post.title" :url="post.url" :image="post.image"
           :placeholder="post.placeholder" :size="post.size" @click="$emit('click', post)">
     <div slot="content" class="card__tags nuggets" :title="tagsStr">
       <da-line-clamp :text="tagsStr" :lines="1" :truncate="truncateTags"/>
@@ -28,11 +28,12 @@
     </template>
     <svgicon icon="menu" class="card__menu--duplicate" ref="dup"
              slot="other" v-if="menuOpened"/>
-  </DaCard>
+  </da-card>
 </template>
 
 <script>
 import 'lazysizes';
+import { truncateTags } from '../truncate';
 import DaCard from './DaCard.vue';
 import DaLineClamp from './DaLineClamp.vue';
 
@@ -96,26 +97,8 @@ export default {
       }, 1500);
     },
 
-    truncateTags(text, maxLength) {
-      const value = this.post.tags;
-      if (!value) {
-        return '';
-      }
-
-      const tags = [];
-      let len = 0;
-      for (let i = 0; i < value.length; i += 1) {
-        if (len + value[i].length < maxLength) {
-          len += value[i].length + 2;
-          tags.push(value[i]);
-        }
-      }
-
-      const suffix = tags.length < value.length ? `,+${value.length - tags.length}` : '';
-      const str = tags
-        .map(tag => `#${tag}`)
-        .join(',');
-      return `${str}${suffix}`;
+    truncateTags(...args) {
+      return truncateTags(this.post.tags, ...args);
     },
 
     positionDuplicate() {

--- a/packages/components/src/components/DaInsanePost.vue
+++ b/packages/components/src/components/DaInsanePost.vue
@@ -5,7 +5,9 @@
         <h5 class="insane__title">
           <da-line-clamp :text="post.title" :lines="3"/>
         </h5>
-        <div class="insane__tags micro1">{{ tags }}</div>
+        <div class="insane__tags micro1" :title="tags">
+          <da-line-clamp :text="tags" :lines="1" :truncate="truncateTags"/>
+        </div>
       </a>
       <span class="insane__views micro2 reveal"
             v-if="post.readTime">// {{post.readTime}} min read</span>
@@ -36,6 +38,7 @@
 
 <script>
 import 'lazysizes';
+import { truncateTags } from '../truncate';
 import DaLineClamp from './DaLineClamp.vue';
 
 export default {
@@ -82,8 +85,8 @@ export default {
   },
 
   mounted() {
-    import('../../icons/bookmark');
-    import('../../icons/menu');
+        import('../../icons/bookmark');
+        import('../../icons/menu');
   },
 
   methods: {
@@ -93,6 +96,10 @@ export default {
       setTimeout(() => {
         this.notifying = false;
       }, 1500);
+    },
+
+    truncateTags(...args) {
+      return truncateTags(this.post.tags, ...args);
     },
   },
 };
@@ -131,6 +138,7 @@ export default {
 .insane__tags {
   margin-top: 4px;
   color: var(--theme-disabled);
+  max-width: 600px;
 }
 
 .insane__views {

--- a/packages/components/src/truncate.js
+++ b/packages/components/src/truncate.js
@@ -1,0 +1,21 @@
+// eslint-disable-next-line import/prefer-default-export
+export const truncateTags = (tags, text, maxLength) => {
+  if (!tags) {
+    return '';
+  }
+
+  const finalTags = [];
+  let len = 0;
+  for (let i = 0; i < tags.length; i += 1) {
+    if (len + tags[i].length < maxLength) {
+      len += tags[i].length + 2;
+      finalTags.push(tags[i]);
+    }
+  }
+
+  const suffix = finalTags.length < tags.length ? `,+${tags.length - finalTags.length}` : '';
+  const str = finalTags
+    .map(tag => `#${tag}`)
+    .join(',');
+  return `${str}${suffix}`;
+};


### PR DESCRIPTION
Use `DaLineClamp` to limit the tags in insane posts to one line.

Closes #25