### PR TITLE
:sparkles: Add 'Do Not Disturb' mode to the extension

### DIFF
--- a/packages/extension/__tests__/DaDndMessage.js
+++ b/packages/extension/__tests__/DaDndMessage.js
@@ -1,0 +1,8 @@
+import { mount } from '@vue/test-utils';
+import DaDndMessage from '../src/components/DaDndMessage.vue';
+
+it('should emit "dndOff" on dnd-mode link click', () => {
+  const wrapper = mount(DaDndMessage);
+  wrapper.find('.dnd-message-bar button').trigger('click');
+  expect(wrapper.emitted().dndOff).toBeTruthy();
+});

--- a/packages/extension/__tests__/DaHeader.js
+++ b/packages/extension/__tests__/DaHeader.js
@@ -155,3 +155,9 @@ it('should mutate state when clicking yes on instruction popup', () => {
   expect(ui.mutations.nextInstruction).toBeCalledWith(expect.anything(), undefined);
   expect(ui.actions.setShowTopSites).toBeCalledWith(expect.anything(), true, undefined);
 });
+
+it('should emit "menu" on dnd-mode button click', () => {
+  const wrapper = mount(DaHeader, { store, localVue });
+  wrapper.find('button.btn-dnd').trigger('click');
+  expect(wrapper.emitted().menu).toBeTruthy();
+});

--- a/packages/extension/__tests__/Home.js
+++ b/packages/extension/__tests__/Home.js
@@ -28,7 +28,7 @@ let store;
 beforeEach(() => {
   window.ga = () => {
   };
-  
+
   feed = {
     namespaced: true,
     state: {
@@ -73,22 +73,25 @@ beforeEach(() => {
       showAd: jest.fn()
     }
   };
-  
+
   ui = {
     namespaced: true,
     enableCardAnimations: true,
     instructionsStep: 0,
     state: {
-      insaneMode: false
+      insaneMode: false,
     },
     mutations: {
-      setInsaneMode: jest.fn()
+      setInsaneMode: jest.fn(),
+      setDndModeTime: jest.fn(),
     },
     getters: {
       topSitesInstructions: jest.fn(),
       sidebarInstructions: jest.fn(),
-      showReadyModal: jest.fn()
-    }
+      showReadyModal: jest.fn(),
+      dndMode: jest.fn(),
+      dndModeTime: jest.fn(),
+    },
   };
 
   user = {
@@ -103,7 +106,7 @@ beforeEach(() => {
       refreshToken: jest.fn()
     }
   };
-  
+
   store = new Vuex.Store({
     modules: { feed, ui, user },
   });
@@ -141,4 +144,10 @@ it('should dispatch "setFilter" with publication filter when in insane mode', (d
     }, undefined);
     done();
   });
+});
+
+it('should commit "setDndModeTime" when "For 1 Hour" or "Until Tomorrow" is clicked', () => {
+  const wrapper = mount(DaHome, { store, localVue });
+  wrapper.find('.btn-dnd-menu').trigger('click');
+  expect(ui.mutations.setDndModeTime).toBeCalledWith(expect.anything(), expect.any(Number));
 });

--- a/packages/extension/__tests__/ui.js
+++ b/packages/extension/__tests__/ui.js
@@ -141,3 +141,22 @@ it('should increment instructionStep', () => {
   module.mutations.nextInstruction(state);
   expect(state.instructionsStep).toEqual(1);
 });
+
+it('should set DND mode time in state and DND mode should be true', () => {
+  const time = new Date().getTime();
+  const state = {};
+  module.mutations.setDndModeTime(state, time);
+  expect(state.dndModeTime).toEqual(time);
+  expect(module.getters.dndMode(state)).toBe(true);
+});
+
+it('DND mode should be false when "setDndModeTime" is not yet committed', () => {
+  const state = { dndModeTime: null };
+  expect(module.getters.dndMode(state)).toBe(false);
+});
+
+it('DND mode should be false when "disableDndMode" is committed', () => {
+  const state = { dndModeTime: 1566300647 };
+  module.mutations.disableDndMode(state);
+  expect(module.getters.dndMode(state)).toBe(false);
+});

--- a/packages/extension/src/components/DaDndMessage.vue
+++ b/packages/extension/src/components/DaDndMessage.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="dnd-message-bar">
+    <p class="micro2">Do not disturb.</p>
+    <button class="nuggets" @click="$emit('dndOff')">Turn Off</button>
+  </div>
+</template>
+
+<style>
+.dnd-message-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 32px;
+  background-color: var(--color-onion-40);
+  text-align: center;
+
+  & p {
+    font-style: oblique;
+  }
+
+  & button {
+    padding: 0;
+    margin-left: 8px;
+    border: none;
+    background-color: inherit;
+    color: var(--color-salt-10);
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}
+</style>

--- a/packages/extension/src/components/DaHeader.vue
+++ b/packages/extension/src/components/DaHeader.vue
@@ -30,6 +30,10 @@
     <button class="btn-icon" title="Daily Go" @click="$emit('go')">
       <svgicon icon="mobile"/>
     </button>
+    <button class="btn-icon btn-dnd"
+            title="Do Not Disturb (DND)" @click="$emit('menu', {event: $event})">
+      <svgicon icon="timer"/>
+    </button>
     <button class="btn-icon btn-terminal" title="Notifications"
             :class="{ 'active': notificationsOpened }" @click="toggleNotifications">
       <svgicon icon="terminal"/>
@@ -86,6 +90,7 @@ export default {
   components: {
     DaIconToggle: () => import('@daily/components/src/components/DaIconToggle.vue'),
     DaSwitch: () => import('@daily/components/src/components/DaSwitch.vue'),
+    DaContext: () => import('@daily/components/src/components/DaContext.vue'),
   },
 
   data() {
@@ -144,6 +149,7 @@ export default {
       import('@daily/components/icons/mobile');
       import('@daily/components/icons/ph');
       import('@daily/components/icons/github');
+      import('@daily/components/icons/timer');
     },
 
     async getTopSites() {

--- a/packages/extension/src/standalone/App.vue
+++ b/packages/extension/src/standalone/App.vue
@@ -74,7 +74,7 @@ export default {
 <style>
 @import '../../../../node_modules/@daily/components/src/styles/global.pcss';
 
-html {
+html.loaded {
   background: var(--theme-background-primary);
 }
 

--- a/packages/extension/src/store/modules/ui.js
+++ b/packages/extension/src/store/modules/ui.js
@@ -5,6 +5,7 @@ import { profileService } from '../../common/services';
 const initialState = () => ({
   theme: null,
   insaneMode: false,
+  dndModeTime: null,
   showTopSites: false,
   notifications: [],
   showNotificationBadge: false,
@@ -27,6 +28,10 @@ export default {
       state.insaneMode = value;
     },
 
+    setDndModeTime(state, value) {
+      state.dndModeTime = value;
+    },
+
     setShowTopSites(state, value) {
       state.showTopSites = value;
     },
@@ -39,6 +44,10 @@ export default {
       state.lastNotificationTime = new Date(state.notifications[0].timestamp.getTime() + 1);
       state.showNotificationBadge = false;
       state.showNotifications = true;
+    },
+
+    disableDndMode(state) {
+      state.dndModeTime = null;
     },
 
     hideNotifications(state) {
@@ -71,11 +80,21 @@ export default {
     topSitesInstructions(state) {
       return state.instructionsStep === 0;
     },
+
     sidebarInstructions(state) {
       return state.instructionsStep === 1;
     },
+
     showReadyModal(state) {
       return state.instructionsStep === 2;
+    },
+
+    dndMode(state) {
+      return state.dndModeTime !== null;
+    },
+
+    dndModeTime(state) {
+      return state.dndModeTime;
     },
   },
   actions: {


### PR DESCRIPTION
This PR resolves Issue #14.

Added  a DND button on the header that has an option of
"For 1 Hour" and "Until Tomorrow"
<img width="209" alt="Screen Shot 2019-08-19 at 5 58 46 PM" src="https://user-images.githubusercontent.com/21978370/63256889-2a83fd00-c2ab-11e9-82ca-f01f81414440.png">

The "Until Tomorrow" button sets the DA on DND mode up until 12 AM or 00:00 hours and enables the DA new tab functionality again.

Whenever the DND mode is activated for chrome and firefox they have different behavior as there's a problem when redirecting the firefox tab to `about:home`.
On Chrome, when DND mode is activated, it'll redirect to Chrome's homepage, but on Firefox it'll redirect to `https://google.com` for now until we find a better solution.

Users can deactivate the DND mode after they had recently activated it through the current tab, if that tab is already closed, they could reactivate the DA through the browser's toolbar by clicking the DA icon.

