### PR TITLE
:see_no_evil: Add .DS_Store to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .rpt2_cache/
+.DS_Store
 
 # Created by .ignore support plugin (hsz.mobi)
 ### Node template


### PR DESCRIPTION
This PR added `.DS_Store` to ignored files at root directory to ignore it even in subdirectories, currently, it is only added at [/packages/extension/.gitignore](https://github.com/dailynowco/daily-apps/blob/6afce7b9e63a7eb90557af91d127930a3139b6e1/packages/extension/.gitignore#L1).