### PR TITLE
refactor(extension): create ad and post mixin

### DIFF
--- a/packages/components/src/common/adMixin.js
+++ b/packages/components/src/common/adMixin.js
@@ -1,0 +1,26 @@
+export default {
+  props: {
+    ad: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    pixel() {
+      return this.ad.pixel || [];
+    },
+
+    promoted() {
+      if (this.ad.company) {
+        return `Promoted by ${this.ad.company}`;
+      }
+
+      return 'Promoted';
+    },
+  },
+
+  mounted() {
+    this.$emit('impression', this.ad);
+  },
+};

--- a/packages/components/src/common/postMixin.js
+++ b/packages/components/src/common/postMixin.js
@@ -1,0 +1,39 @@
+import { truncateTags } from '../truncate';
+
+export default {
+  props: {
+    post: {
+      type: Object,
+      required: true,
+    },
+    menuOpened: {
+      type: Boolean,
+      default: false,
+    },
+    showMenu: {
+      type: Boolean,
+      default: true,
+    },
+  },
+
+  data() {
+    return {
+      notifying: false,
+      notification: '',
+    };
+  },
+
+  methods: {
+    notify(notification) {
+      this.notification = notification;
+      this.notifying = true;
+      setTimeout(() => {
+        this.notifying = false;
+      }, 1000);
+    },
+
+    truncateTags(...args) {
+      return truncateTags(this.post.tags, ...args);
+    },
+  },
+};

--- a/packages/components/src/components/DaCardAd.vue
+++ b/packages/components/src/components/DaCardAd.vue
@@ -14,37 +14,17 @@
 
 <script>
 import DaCard from './DaCard.vue';
+import adMixin from '../common/adMixin';
 
 export default {
   name: 'DaCardAd',
+  mixins: [adMixin],
   components: { DaCard },
-  props: {
-    ad: {
-      type: Object,
-      required: true,
-    },
-  },
 
   computed: {
     size() {
       return this.ad.size || 'small';
     },
-
-    pixel() {
-      return this.ad.pixel || [];
-    },
-
-    promoted() {
-      if (this.ad.company) {
-        return `Promoted by ${this.ad.company}`;
-      }
-
-      return 'Promoted';
-    },
-  },
-
-  mounted() {
-    this.$emit('impression', this.ad);
   },
 };
 </script>

--- a/packages/components/src/components/DaCardPost.vue
+++ b/packages/components/src/components/DaCardPost.vue
@@ -36,34 +36,14 @@
 
 <script>
 import 'lazysizes';
-import { truncateTags } from '../truncate';
+import postMixin from '../common/postMixin';
 import DaCard from './DaCard.vue';
 import DaLineClamp from './DaLineClamp.vue';
 
 export default {
   name: 'DaCardPost',
+  mixins: [postMixin],
   components: { DaCard, DaLineClamp },
-  props: {
-    post: {
-      type: Object,
-      required: true,
-    },
-    menuOpened: {
-      type: Boolean,
-      default: false,
-    },
-    showMenu: {
-      type: Boolean,
-      default: true,
-    },
-  },
-
-  data() {
-    return {
-      notifying: false,
-      notification: '',
-    };
-  },
 
   watch: {
     menuOpened() {
@@ -92,18 +72,6 @@ export default {
   },
 
   methods: {
-    notify(notification) {
-      this.notification = notification;
-      this.notifying = true;
-      setTimeout(() => {
-        this.notifying = false;
-      }, 1000);
-    },
-
-    truncateTags(...args) {
-      return truncateTags(this.post.tags, ...args);
-    },
-
     positionDuplicate() {
       if (this.menuOpened) {
         this.$nextTick(() => {

--- a/packages/components/src/components/DaInsaneAd.vue
+++ b/packages/components/src/components/DaInsaneAd.vue
@@ -14,37 +14,13 @@
 
 <script>
 import DaLineClamp from './DaLineClamp.vue';
+import adMixin from '../common/adMixin';
 
 export default {
   name: 'DaInsandeAd',
-
+  mixins: [adMixin],
   components: {
     DaLineClamp,
-  },
-
-  props: {
-    ad: {
-      type: Object,
-      required: true,
-    },
-  },
-
-  computed: {
-    pixel() {
-      return this.ad.pixel || [];
-    },
-
-    promoted() {
-      if (this.ad.company) {
-        return `Promoted by ${this.ad.company}`;
-      }
-
-      return 'Promoted';
-    },
-  },
-
-  mounted() {
-    this.$emit('impression', this.ad);
   },
 };
 </script>

--- a/packages/components/src/components/DaInsanePost.vue
+++ b/packages/components/src/components/DaInsanePost.vue
@@ -41,36 +41,14 @@
 
 <script>
 import 'lazysizes';
-import { truncateTags } from '../truncate';
+import postMixin from '../common/postMixin';
 import DaLineClamp from './DaLineClamp.vue';
 
 export default {
   name: 'DaInsanePost',
-
+  mixins: [postMixin],
   components: {
     DaLineClamp,
-  },
-
-  props: {
-    post: {
-      type: Object,
-      required: true,
-    },
-    menuOpened: {
-      type: Boolean,
-      default: false,
-    },
-    showMenu: {
-      type: Boolean,
-      default: true,
-    },
-  },
-
-  data() {
-    return {
-      notifying: false,
-      notification: '',
-    };
   },
 
   computed: {
@@ -88,22 +66,8 @@ export default {
   },
 
   mounted() {
-        import('../../icons/bookmark');
-        import('../../icons/menu');
-  },
-
-  methods: {
-    notify(notification) {
-      this.notification = notification;
-      this.notifying = true;
-      setTimeout(() => {
-        this.notifying = false;
-      }, 1000);
-    },
-
-    truncateTags(...args) {
-      return truncateTags(this.post.tags, ...args);
-    },
+    import('../../icons/bookmark');
+    import('../../icons/menu');
   },
 };
 </script>


### PR DESCRIPTION
The new mixins hold the common functionality of ad and post accordingly.
Until now this code was duplicated in the insane and card versions and was hard to maintain.