### PR TITLE
fix(components): prevent xss attacks

### DIFF
--- a/packages/components/src/components/DaLineClamp.vue
+++ b/packages/components/src/components/DaLineClamp.vue
@@ -77,9 +77,9 @@ export default {
 
     updateHtml() {
       if (!this.offset) {
-        this.$refs.content.innerHTML = this.text;
+        this.$refs.content.textContent = this.text;
       } else {
-        this.$refs.content.innerHTML = this.truncate(this.text, this.text.length - this.offset);
+        this.$refs.content.textContent = this.truncate(this.text, this.text.length - this.offset);
       }
     },
   },


### PR DESCRIPTION
By using the `textContent` property instead of `innerHTML`, XSS attack is prevented

Closes dailynowco/daily#116