### PR TITLE
feat(extension): sort main feed by popularity or creation time

### DIFF
--- a/packages/extension/__tests__/feed.js
+++ b/packages/extension/__tests__/feed.js
@@ -437,3 +437,20 @@ it('should remove post from feed', () => {
     id: '3',
   }]);
 });
+
+it('should set sort by in state', () => {
+  const state = {};
+  module.mutations.setSortBy(state, 'popularity');
+  expect(state.sortBy).toEqual('popularity');
+});
+
+it('should set sort by and refresh feed', async () => {
+  const state = {};
+  await testAction(
+    module.actions.setSortBy,
+    'creation',
+    state,
+    [{ type: 'setSortBy', payload: 'creation' }],
+    [{ type: 'refreshFeed', payload: null }],
+  );
+});

--- a/packages/extension/src/routes/Home.vue
+++ b/packages/extension/src/routes/Home.vue
@@ -25,7 +25,7 @@
     <da-settings v-if="showSettings"/>
     <main class="content">
       <div class="content__header">
-        <template v-if="filter && !showBookmarks">
+        <template v-if="showFilterHeader">
           <button class="btn btn-nav content__header__back-home" @click="onBackHome">
             <svgicon icon="arrow"/>
             <span>Back Home</span>
@@ -42,7 +42,15 @@
           </transition>
         </template>
         <template v-else>
-          <h4 v-if="!emptyBookmarks" class="uppercase">/* {{ title }} */</h4>
+          <h4 v-if="!emptyBookmarks && showBookmarks" class="uppercase">/* {{ title }} */</h4>
+          <template v-if="showMainFeed">
+            <button class="btn btn-menu sort-by" :class="{'not-selected': sortBy !== 'popularity'}"
+                    @click="setSortBy('popularity')">Popular
+            </button>
+            <button class="btn btn-menu sort-by" :class="{'not-selected': sortBy !== 'creation'}"
+                    @click="setSortBy('creation')">Recent
+            </button>
+          </template>
           <a class="header__cta shadow1 " :href="cta.link" target="_blank"
              @mouseup="ctaClick" :style="cta.style">
             <span class="header__cta__text">// {{cta.text}}</span>
@@ -227,6 +235,11 @@ export default {
       this.addFilterToFeed();
     },
 
+    setSortBy(value) {
+      ga('send', 'event', 'Feed', 'Sort By', value);
+      this.$store.dispatch('feed/setSortBy', value);
+    },
+
     async initHome() {
       Promise.all([
         this.fetchPublications(),
@@ -278,7 +291,7 @@ export default {
   computed: {
     ...mapState('ui', ['notifications', 'showNotifications', 'showSettings', 'theme', 'showDndMenu']),
     ...mapGetters('ui', ['sidebarInstructions', 'showReadyModal', 'dndMode']),
-    ...mapState('feed', ['showBookmarks', 'filter']),
+    ...mapState('feed', ['showBookmarks', 'filter', 'sortBy']),
     ...mapState({
       title(state) {
         let res = '';
@@ -317,9 +330,14 @@ export default {
       hasFilter: 'feed/hasFilter',
       isLoggedIn: 'user/isLoggedIn',
     }),
-
     emptyBookmarks() {
       return !this.posts.length && this.showBookmarks;
+    },
+    showFilterHeader() {
+      return this.filter && !this.showBookmarks;
+    },
+    showMainFeed() {
+      return !this.showBookmarks && !this.filter;
     },
   },
 
@@ -671,6 +689,17 @@ export default {
 
   & .stroke {
     stroke: var(--theme-separator);
+  }
+}
+
+.btn.sort-by {
+  margin: 0 -4px;
+  pointer-events: none;
+
+  &.not-selected {
+    pointer-events: all;
+    color: var(--theme-secondary);
+    @mixin lil1;
   }
 }
 </style>

--- a/packages/extension/src/store/modules/feed.js
+++ b/packages/extension/src/store/modules/feed.js
@@ -21,6 +21,7 @@ const initialState = () => ({
   bookmarks: [],
   latest: null,
   filter: null,
+  sortBy: 'popularity',
 });
 
 const isLoggedIn = state => !!state.user.profile;
@@ -54,13 +55,13 @@ const fetchPosts = async (state, loggedIn) => {
   }
 
   if (loggedIn) {
-    return contentService.fetchLatestPosts(state.latest, state.page);
+    return contentService.fetchLatestPosts(state.latest, state.page, state.sortBy);
   }
 
   const enabledPubs = state.publications.filter(p => p.enabled).map(p => p.id);
   const pubs = enabledPubs.length === state.publications.length ? [] : enabledPubs;
   const tags = state.tags.filter(t => t.enabled).map(t => t.name);
-  return contentService.fetchLatestPosts(state.latest, state.page, pubs, tags);
+  return contentService.fetchLatestPosts(state.latest, state.page, pubs, tags, state.sortBy);
 };
 
 const getFeed = (state) => {
@@ -168,6 +169,9 @@ export default {
       state.publications = state.publications.map(p => ({ ...p, enabled: true }));
       state.tags = state.tags.map(t => ({ ...t, enabled: false }));
       state.showBookmarks = false;
+    },
+    setSortBy(state, sortBy) {
+      state.sortBy = sortBy;
     },
   },
   actions: {
@@ -314,6 +318,11 @@ export default {
       }
 
       return Promise.resolve();
+    },
+
+    setSortBy({ commit, dispatch }, value) {
+      commit('setSortBy', value);
+      return dispatch('refreshFeed');
     },
   },
 };

--- a/packages/services/__tests__/content.ts
+++ b/packages/services/__tests__/content.ts
@@ -147,6 +147,7 @@ it('should fetch latest posts from server', async () => {
         pageSize: 5,
         pubs: 'airbnb,alligator,angular',
         tags: 'angular,vue,webdev',
+        sortBy: 'popularity',
     };
 
     const query = `${encode(fetchLatestQuery)}&variables=${encode(JSON.stringify({params: inputParams}))}`;
@@ -170,6 +171,7 @@ it('should fetch personal latest posts from server', async () => {
         latest: '2018-11-28T08:27:45.612Z',
         page: 0,
         pageSize: 5,
+        sortBy: 'popularity',
     };
 
     const query = `${encode(fetchPersonalLatestQuery)}&variables=${encode(JSON.stringify({params: inputParams}))}`;
@@ -240,6 +242,7 @@ it('should clear access token', async () => {
         latest: '2018-11-28T08:27:45.612Z',
         page: 0,
         pageSize: 5,
+        sortBy: 'popularity',
     };
 
     const query1 = `${encode(fetchPersonalLatestQuery)}&variables=${encode(JSON.stringify({params: inputParams}))}`;

--- a/packages/services/src/content.ts
+++ b/packages/services/src/content.ts
@@ -205,13 +205,14 @@ export class ContentServiceImpl implements ContentService {
         await this.request.post(`/v1/posts/${postId}/hide`);
     }
 
-    async fetchLatestPosts(latest: Date, page: number, pubs?: string[], tags?: string[]): Promise<Post[]> {
+    async fetchLatestPosts(latest: Date, page: number, pubs?: string[], tags?: string[], sortBy: string = 'popularity'): Promise<Post[]> {
         const inputParams = {
             latest: latest.toISOString(),
             page,
             pageSize: this.pageSize,
             ...pubs && {pubs: pubs.join()},
             ...tags && {tags: tags.join()},
+            sortBy,
         };
 
         const {data: res} = await this.request.get('/graphql', {


### PR DESCRIPTION
The main feed introduces a method for a user to choose the sorting criteria.
Currently, two options are available by popularity or creation time.

Closes dailynowco/daily#112