### PR TITLE
fix: cpu consumption when resizing quickly the window

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -14,6 +14,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "debounce": "^1.2.0",
     "dialog-polyfill": "^0.4.10",
     "dompurify": "^2.0.7",
     "lazysizes": "^4.1.4",

--- a/packages/components/src/components/DaLineClamp.vue
+++ b/packages/components/src/components/DaLineClamp.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script>
+import { debounce } from 'debounce';
+
 const elements = [];
-window.addEventListener('resize', () => {
+window.addEventListener('resize', debounce(() => {
   elements.forEach(el => el.updateText());
-});
+}, 400));
 
 const ellipsis = (text, maxLength) => {
   if (text.length <= maxLength) {
@@ -60,17 +62,25 @@ export default {
     updateText() {
       let i = 1;
       if (this.offset) {
-        while (!this.isOverflow() && this.offset) {
+        while (!this.isOverflow() && this.offset > 0) {
           this.offset -= i * 2;
           i += 1;
+          this.updateHtml();
+        }
+        if (this.offset < 0) {
+          this.offset = 0;
           this.updateHtml();
         }
       }
 
       i = 1;
-      while (this.isOverflow()) {
+      while (this.isOverflow() && this.offset < this.text.length) {
         this.offset += i * 2;
         i += 1;
+        this.updateHtml();
+      }
+      if (this.offset > this.text.length) {
+        this.offset = this.text.length;
         this.updateHtml();
       }
     },

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -5089,6 +5089,11 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Upon resizing the `DaLineClamp` component could get into an infinite loop and by that breaking the page and the browser.

Closes dailynowco/daily#128